### PR TITLE
Update the scripts to support Microgateway 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ Usage:
 -h: Display this help and exit.
 ```
 
+Performance test script options. (run_performance_test_options)
+```
+-m: Application heap memory sizes. You can give multiple options to specify multiple heap memory sizes. Allowed suffixes: M, G.
+-u: Concurrent Users to test. You can give multiple options to specify multiple users.
+-b: Message sizes in bytes. You can give multiple options to specify multiple message sizes.
+-s: Backend Sleep Times in milliseconds. You can give multiple options to specify multiple sleep times.
+-d: Test Duration in seconds. Default 900.
+-w: Warm-up time in seconds. Default 300.
+-j: Heap Size of JMeter Server. Allowed suffixes: M, G. Default 4G.
+-k: Heap Size of JMeter Client. Allowed suffixes: M, G. Default 2G.
+-l: Heap Size of Netty Service. Allowed suffixes: M, G. Default 4G.
+-i: Scenario name to to be included. You can give multiple options to filter scenarios.
+-e: Scenario name to to be excluded. You can give multiple options to filter scenarios.
+```
+
 ### Testing WSO2 API Microgateway
 
 Use `cloudformation/run-micro-gw-performance-tests.sh` to run performance tests on WSO2 API Microgateway.
@@ -196,6 +211,22 @@ Usage:
 -w: The minimum time to wait in minutes before polling for cloudformation stack's CREATE_COMPLETE status.
     Default: 5.
 -h: Display this help and exit.
+```
+
+Performance test script options. (run_performance_test_options)
+```
+-m: Application heap memory sizes. You can give multiple options to specify multiple heap memory sizes. Allowed suffixes: M, G.
+-u: Concurrent Users to test. You can give multiple options to specify multiple users.
+-b: Message sizes in bytes. You can give multiple options to specify multiple message sizes.
+-s: Backend Sleep Times in milliseconds. You can give multiple options to specify multiple sleep times.
+-d: Test Duration in seconds. Default 900.
+-w: Warm-up time in seconds. Default 300.
+-j: Heap Size of JMeter Server. Allowed suffixes: M, G. Default 4G.
+-k: Heap Size of JMeter Client. Allowed suffixes: M, G. Default 2G.
+-l: Heap Size of Netty Service. Allowed suffixes: M, G. Default 4G.
+-c: Number of cpus (--cpus option for docker)
+-i: Scenario name to to be included. You can give multiple options to filter scenarios.
+-e: Scenario name to to be excluded. You can give multiple options to filter scenarios.
 ```
 
 ## Running performance tests on other enviroments

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package (**performance-apim-distribution-${version}.tar.gz**) built by the d
 The scripts in this repository depend on the scripts in
  "[performance-common](https://github.com/wso2/performance-common/)" repository.
 
-**Note:** The scripts are only compatible with **WSO2 API Manager 2.6.0**.
+**Note:** The scripts are only compatible with **WSO2 API Manager 3.1.0**.
 
 Following is the recommended deployment for performance testing All-in-one WSO2 API Manager.
 

--- a/components/jwt-generator/src/main/java/org/wso2/performance/apim/microgw/jwt/JWTGenerator.java
+++ b/components/jwt-generator/src/main/java/org/wso2/performance/apim/microgw/jwt/JWTGenerator.java
@@ -111,7 +111,7 @@ public class JWTGenerator {
         try (BufferedWriter tokensWriter = new BufferedWriter(new FileWriter(outputFile))) {
             for (int i = 1; i <= tokensCount; i++) {
                 JSONObject jwtTokenInfo = new JSONObject();
-                jwtTokenInfo.put("aud", "http://org.wso2.apimgt/gateway");
+                jwtTokenInfo.put("aud", consumerKey);
                 jwtTokenInfo.put("sub", "admin@carbon.super");
                 jwtTokenInfo.put("scope", "am_application_scope default");
                 jwtTokenInfo.put("iss", "https://localhost:9443/oauth2/token");
@@ -121,7 +121,7 @@ public class JWTGenerator {
                 jwtTokenInfo.put("nbf", (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));        
                 jwtTokenInfo.put("iat", (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
                 jwtTokenInfo.put("jti", UUID.randomUUID());
-                jwtTokenInfo.put("consumerKey", consumerKey);
+                jwtTokenInfo.put("azp", consumerKey);
 
                 String payload = jwtTokenInfo.toString();
                 String base64UrlEncodedBody = Base64.getUrlEncoder()

--- a/distribution/scripts/apim/apim-start.sh
+++ b/distribution/scripts/apim/apim-start.sh
@@ -84,9 +84,17 @@ echo "Setting Heap to ${heap_size}"
 export JVM_MEM_OPTS="-Xms${heap_size} -Xmx${heap_size}"
 
 echo "Enabling GC Logs"
-#export JAVA_OPTS="-XX:+PrintGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/ubuntu/wso2am/repository/logs/gc.log"
-export JAVA_OPTS="-Xlog:gc*,safepoint,gc+heap=trace:file=/home/ubuntu/wso2am/repository/logs/gc.log:uptime,utctime,level,tags "
+JAVA_COMMAND="$JAVA_HOME/bin/java"
+JAVA_VERSION=$("$JAVA_COMMAND" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ $JAVA_VERSION =~ ^1\.8.* ]]; then
+    export JAVA_OPTS="-XX:+PrintGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/ubuntu/wso2am/repository/logs/gc.log"
+else 
+    # for jdk11
+    export JAVA_OPTS="-Xlog:gc*,safepoint,gc+heap=trace:file=/home/ubuntu/wso2am/repository/logs/gc.log:uptime,utctime,level,tags "
+fi
 
+# export JAVA_OPTS="-Xlog:gc*,safepoint,gc+heap=trace:file=/home/ubuntu/wso2am/repository/logs/gc.log:uptime,utctime,level,tags "
+# export JAVA_OPTS="-XX:+PrintGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/ubuntu/wso2am/repository/logs/gc.log"
 # Enable this JAVA_OPTS and comment out above JAVA_OPTS to enable JFR recording. To retrive this recording uncomment 
 # last line in after_execute_test_scenario() method in run-performance-tests.sh file. Set the correct duration and delay (default delay=30s,duration=15m)
 # Note: recording file size takes about 600MB. DO NOT ENABLE it for full test runs. 

--- a/distribution/scripts/apim/create-api.sh
+++ b/distribution/scripts/apim/create-api.sh
@@ -293,8 +293,7 @@ subscription_request() {
 { 
    "apiId":"$1",
    "applicationId":"$application_id",
-   "throttlingPolicy":"Unlimited",
-   "type":"API"
+   "throttlingPolicy":"Unlimited"
 }
 EOF
 }

--- a/distribution/scripts/apim/create-api.sh
+++ b/distribution/scripts/apim/create-api.sh
@@ -160,7 +160,7 @@ app_request() {
 EOF
 }
 
-client_credentials=$($curl_command -u admin:admin -H "Content-Type: application/json" -d "$(client_request)" ${base_https_url}/client-registration/v0.16/register | jq -r '.clientId + ":" + .clientSecret')
+client_credentials=$($curl_command -u admin:admin -H "Content-Type: application/json" -d "$(client_request)" ${base_https_url}/client-registration/v0.17/register | jq -r '.clientId + ":" + .clientSecret')
 
 get_access_token() {
     local access_token=$($curl_command -d "grant_type=password&username=admin&password=admin&scope=apim:$1" -u $client_credentials ${nio_https_url}/token | jq -r '.access_token')

--- a/distribution/scripts/apim/generate-jwt-tokens.sh
+++ b/distribution/scripts/apim/generate-jwt-tokens.sh
@@ -86,9 +86,7 @@ fi
 
 application_id=$(cat $application_id_file)
 
-generate_tokens_command="java -Xms128m -Xmx128m -jar $script_dir/micro-gw/jwt-generator-0.1.1-SNAPSHOT.jar --api-name "echo,mediation" \
-        --context "echo,mediation" --version "1.0.0,1.0.0" --app-name "PerformanceTestAPP" --app-owner "admin" --consumer-key "$consumer_key"\
-        --app-tier "Unlimited" --subs-tier "Unlimited" --app-uuid "$application_id" \
+generate_tokens_command="java -Xms128m -Xmx128m -jar $script_dir/micro-gw/jwt-generator-0.1.1-SNAPSHOT.jar --consumer-key "$consumer_key"\
         --key-store-file $script_dir/jwt/wso2carbon.jks \
         --tokens-count $tokens_count --output-file $tokens_file"
 echo "Generating Tokens: $generate_tokens_command"

--- a/distribution/scripts/apim/generate-jwt-tokens.sh
+++ b/distribution/scripts/apim/generate-jwt-tokens.sh
@@ -19,6 +19,7 @@
 
 script_dir=$(dirname "$0")
 tokens_count=""
+tokens_file_name=""
 
 function usage() {
     echo ""
@@ -30,11 +31,14 @@ function usage() {
     echo ""
 }
 
-while getopts "t:h" opt; do
+while getopts "t:a:h" opt; do
     case "${opt}" in
     t)
         tokens_count=${OPTARG}
         ;;
+    a)
+        tokens_file_name=${OPTARG}
+        ;;    
     h)
         usage
         exit 0
@@ -53,7 +57,12 @@ if [[ -z $tokens_count ]]; then
 fi
 
 mkdir -p "$script_dir/target"
-tokens_file="$script_dir/target/tokens.csv"
+
+if [[ -z $tokens_file_name ]]; then
+    tokens_file="$script_dir/target/tokens.csv"
+else
+    tokens_file="$script_dir/target/${tokens_file_name}"
+fi
 
 if [[ -f $tokens_file ]]; then
     mv $tokens_file /tmp

--- a/distribution/scripts/apim/micro-gw/create-micro-gw-conf.sh
+++ b/distribution/scripts/apim/micro-gw/create-micro-gw-conf.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Copyright 2019 WSO2 Inc. (http://wso2.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ----------------------------------------------------------------------------
+# Start WSO2 API Manager Micro Gateway Configuration
+# ----------------------------------------------------------------------------
+while getopts "i:" opt; do
+    case "${opt}" in
+    i)
+        host_ip=${OPTARG}
+        ;;
+    esac
+done
+
+echo "[listenerConfig]
+host=\"0.0.0.0\"
+httpPort=9090
+httpsPort=9095
+keyStorePath=\"\${ballerina.home}/bre/security/ballerinaKeystore.p12\"
+keyStorePassword=\"ballerina\"
+trustStorePath=\"\${ballerina.home}/bre/security/ballerinaTruststore.p12\"
+trustStorePassword=\"ballerina\"
+tokenListenerPort=9096
+
+[authConfig]
+authorizationHeader=\"Authorization\"
+removeAuthHeaderFromOutMessage=true
+
+[keyManager]
+serverUrl=\"https://${host_ip}:9443\"
+username=\"admin\"
+password=\"admin\"
+tokenContext=\"oauth2\"
+timestampSkew=5000
+
+[jwtTokenConfig]
+issuer=\"https://localhost:9443/oauth2/token\"
+audience=\"http://org.wso2.apimgt/gateway\"
+certificateAlias=\"wso2apim310\"
+
+[jwtConfig]
+header=\"X-JWT-Assertion\"
+
+[caching]
+enabled=true
+tokenCacheExpiryTime=900000
+tokenCacheCapacity=10000
+tokenCacheEvictionFactor=0.25
+
+[analytics]
+enable=false
+uploadingTimeSpanInMillis=600000
+initialDelayInMillis=5000
+uploadingEndpoint=\"https://${host_ip}:9444/analytics/v1.0/usage/upload-file\"
+rotatingPeriod=600000
+taskUploadFiles=true
+username=\"admin\"
+password=\"admin\"
+
+[http2]
+enable=false
+
+[mutualSSLConfig]
+protocolName=\"TLS\"
+protocolVersions=\"TLSv1.2,TLSv1.1\"
+ciphers=\"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  ,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256, TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_DSS_WITH_AES_128_GCM_SHA256  ,TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA, SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,TLS_EMPTY_RENEGOTIATION_INFO_SCSV\"
+sslVerifyClient=\"optional\"
+
+#[b7a.users]
+#[b7a.users.generalUser1]
+#password=\"5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8\"
+
+[validationConfig]
+enableRequestValidation = false
+enableResponseValidation = false
+
+[throttlingConfig]
+enabledGlobalTMEventPublishing = false
+jmsConnectioninitialContextFactory = \"bmbInitialContextFactory\"
+jmsConnectionProviderUrl= \"amqp://admin:admin@carbon/carbon?brokerlist='tcp://${host_ip}:5672'\"
+jmsConnectionUsername = ""
+jmsConnectionPassword = ""
+throttleEndpointUrl = \"https://${host_ip}:9443/endpoints\"
+throttleEndpointbase64Header = \"admin:admin\"
+[tokenRevocationConfig]
+  [tokenRevocationConfig.realtime]
+    enableRealtimeMessageRetrieval = false
+    jmsConnectionTopic = \"tokenRevocation\"
+    jmsConnectioninitialContextFactory = \"bmbInitialContextFactory\"
+    jmsConnectionProviderUrl= \"amqp://admin:admin@carbon/carbon?brokerlist='tcp://${host_ip}:5672'\"
+    jmsConnectionUsername = \"\"
+    jmsConnectionPassword = \"\"
+  [tokenRevocationConfig.persistent]
+    enablePersistentStorageRetrieval = false
+    useDefault = true
+    hostname = \"https://127.0.0.1:2379/v2/keys/jti/\"
+    username = \"root\"
+    password = \"root\"
+
+[httpClients]
+  verifyHostname=false" > micro-gw.conf

--- a/distribution/scripts/apim/micro-gw/create-micro-gw.sh
+++ b/distribution/scripts/apim/micro-gw/create-micro-gw.sh
@@ -16,7 +16,7 @@
 # ----------------------------------------------------------------------------
 # Setup WSO2 API Microgateway Project
 # ----------------------------------------------------------------------------
-spawn micro-gw setup echo-mgw -a echo -v 1.0.0 -f
+spawn micro-gw import echo-mgw -a echo -v 1.0.0
 expect -exact "Enter Username:"
 send -- "admin\r"
 expect -exact "Enter Password for admin:"

--- a/distribution/scripts/apim/micro-gw/toolkit-config.toml
+++ b/distribution/scripts/apim/micro-gw/toolkit-config.toml
@@ -1,0 +1,23 @@
+[client]
+httpRequestTimeout = 1000000
+
+[token]
+baseURL = ""
+restVersion = "v0.14"
+dcrVersion = "v0.14"
+publisherEndpoint = "{baseURL}/api/am/publisher/{restVersion}"
+adminEndpoint = "{baseURL}/api/am/admin/{restVersion}"
+registrationEndpoint = "{baseURL}/client-registration/{dcrVersion}/register"
+tokenEndpoint = "{baseURL}/oauth2/token"
+username = ""
+clientId = ""
+clientSecret = ""
+trustStoreLocation = ""
+trustStorePassword = ""
+
+[corsConfiguration]
+corsConfigurationEnabled = false
+accessControlAllowCredentials = false
+accessControlAllowOrigins = ["*"]
+accessControlAllowHeaders = ["authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction"]
+accessControlAllowMethods = ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]

--- a/distribution/scripts/cloudformation/run-micro-gw-performance-tests.sh
+++ b/distribution/scripts/cloudformation/run-micro-gw-performance-tests.sh
@@ -31,7 +31,7 @@ export wso2am_rds_db_instance_class=""
 export aws_cloudformation_template_filename="apim_micro_gw_perf_test_cfn.yaml"
 export application_name="WSO2 API Microgateway"
 export ec2_instance_name="wso2am"
-export metrics_file_prefix="microgateway"
+export metrics_file_prefix="apim"
 export run_performance_tests_script_name="run-micro-gw-performance-tests.sh"
 
 function usageCommand() {

--- a/distribution/scripts/jmeter/create-charts.py
+++ b/distribution/scripts/jmeter/create-charts.py
@@ -31,7 +31,7 @@ df = df.loc[df['Error Count'] < 100]
 # Format message size values
 df['Message Size (Bytes)'] = df['Message Size (Bytes)'].map(apimchart.format_bytes)
 
-unique_sleep_times = df['Sleep Time (ms)'].unique()
+unique_sleep_times = df['Back-end Service Delay (ms)'].unique()
 unique_message_sizes = df['Message Size (Bytes)'].unique()
 
 
@@ -41,7 +41,7 @@ def save_line_chart(chart, column, title, ylabel=None):
     fig, ax = plt.subplots()
     fig.set_size_inches(8, 6)
     sns_plot = sns.pointplot(x="Concurrent Users", y=column, hue="Message Size (Bytes)",
-                             data=df.loc[df['Sleep Time (ms)'] == sleep_time], ci=None, dodge=True)
+                             data=df.loc[df['Back-end Service Delay (ms)'] == sleep_time], ci=None, dodge=True)
     ax.yaxis.set_major_formatter(tkr.FuncFormatter(lambda y, p: "{:,}".format(y)))
     plt.suptitle(title)
     if ylabel is None:
@@ -58,10 +58,10 @@ def save_bar_chart(title):
     print("Creating chart: " + title + ", File name: " + filename)
     fig, ax = plt.subplots()
     fig.set_size_inches(8, 6)
-    df_results = df.loc[(df['Message Size (Bytes)'] == message_size) & (df['Sleep Time (ms)'] == sleep_time)]
+    df_results = df.loc[(df['Message Size (Bytes)'] == message_size) & (df['Back-end Service Delay (ms)'] == sleep_time)]
     df_results = df_results[
-        ['Message Size (Bytes)', 'Concurrent Users', 'Min (ms)', '90th Percentile (ms)', '95th Percentile (ms)',
-         '99th Percentile (ms)', 'Max (ms)']]
+        ['Message Size (Bytes)', 'Concurrent Users', 'Minimum Response Time (ms)', '90th Percentile of Response Time (ms)', '95th Percentile of Response Time (ms)',
+         '99th Percentile of Response Time (ms)', 'Maximum Response Time (ms)']]
     df_results = df_results.set_index(['Message Size (Bytes)', 'Concurrent Users']).stack().reset_index().rename(
         columns={'level_2': 'Summary', 0: 'Response Time (ms)'})
     sns.barplot(x='Concurrent Users', y='Response Time (ms)', hue='Summary', data=df_results, ci=None)
@@ -74,20 +74,20 @@ def save_bar_chart(title):
 
 
 for sleep_time in unique_sleep_times:
-    save_line_chart("thrpt", "Throughput", "Throughput vs Concurrent Users for " + str(sleep_time) + "ms backend delay",
+    save_line_chart("thrpt", "Throughput (Requests/sec)", "Throughput vs Concurrent Users for " + str(sleep_time) + "ms backend delay",
                     ylabel="Throughput (Requests/sec)")
-    save_line_chart("avgt", "Average (ms)",
+    save_line_chart("avgt", "Average Response Time (ms)",
                     "Average Response Time vs Concurrent Users for " + str(sleep_time) + "ms backend delay",
                     ylabel="Average Response Time (ms)")
-    save_line_chart("gc", "API Manager GC Throughput (%)",
+    save_line_chart("gc", "WSO2 API Manager GC Throughput (%)",
                     "GC Throughput vs Concurrent Users for " + str(sleep_time) + "ms backend delay",
                     ylabel="GC Throughput (%)")
-    df_results = df.loc[df['Sleep Time (ms)'] == sleep_time]
+    df_results = df.loc[df['Back-end Service Delay (ms)'] == sleep_time]
     chart_suffix = "_" + str(sleep_time) + "ms"
     apimchart.save_multi_columns_categorical_charts(df_results, "loadavg" + chart_suffix,
-                                                    ['API Manager Load Average - Last 1 minute',
-                                                     'API Manager Load Average - Last 5 minutes',
-                                                     'API Manager Load Average - Last 15 minutes'],
+                                                    ['WSO2 API Manager - System Load Average - Last 1 minute',
+                                                     'WSO2 API Manager - System Load Average - Last 5 minutes',
+                                                     'WSO2 API Manager - System Load Average - Last 15 minutes'],
                                                     "Load Average", "API Manager",
                                                     "Load Average with " + str(sleep_time) + "ms backend delay")
     apimchart.save_multi_columns_categorical_charts(df_results, "network" + chart_suffix,
@@ -95,8 +95,8 @@ for sleep_time in unique_sleep_times:
                                                     "Network Throughput (KB/sec)", "Network",
                                                     "Network Throughput with " + str(sleep_time) + "ms backend delay")
     apimchart.save_multi_columns_categorical_charts(df_results, "response_time" + chart_suffix,
-                                                    ['90th Percentile (ms)', '95th Percentile (ms)',
-                                                     '99th Percentile (ms)'],
+                                                    ['90th Percentile of Response Time (ms)', '95th Percentile of Response Time (ms)',
+                                                     '99th Percentile of Response Time (ms)'],
                                                     "Response Time (ms)", "Response Time",
                                                     "Response Time Percentiles with " + str(sleep_time)
                                                     + "ms backend delay", kind='bar')

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <org.json.version>20180813</org.json.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <performance.apim.version>0.1.1-SNAPSHOT</performance.apim.version>
-        <performance.common.version>0.3.1-SNAPSHOT</performance.common.version>
+        <performance.common.version>0.4.6-SNAPSHOT</performance.common.version>
         <!-- Maven Plugins -->
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>


### PR DESCRIPTION
## Purpose
> Update the scripts to do the performance tests for microgateway 3.1.0  along with API Manager 3.1.0. 
> Update the performance-common dependency.

## Goals
> Run performance tests for microgateway 3.1.0

## Remarks
> The current test is designed to run the microgateway in a docker container. The API Manager will run on the same node to reduce the network delay in the Oauth2 scenario. 
> The number of cores allocated to the microgateway docker container is decided from the -c parameter. The default value would be 1.
> The microgateway project is generated using the import method. If it is not required to have the API Manager up and running, the API manager can be stopped once the microgateway project is completed. In such scenario, the Oauth2 test scenario also needs to be removed.